### PR TITLE
Added Column.SetSortType

### DIFF
--- a/src/MvcJqGrid.Tests/ColumnTests.cs
+++ b/src/MvcJqGrid.Tests/ColumnTests.cs
@@ -485,6 +485,32 @@ namespace MvcJqGrid.Tests
             JavascriptAssertColumn.IsValid(column);
         }
 
+        [Test]
+        public void CanSetSortType()
+        {
+            var column = GetTestableColumn();
+
+            column.SetSortType(SortType.Currency);
+            StringAssert.Contains("sorttype:'currency'", column.ToString());
+
+            column.SetSortType(SortType.Date);
+            StringAssert.Contains("sorttype:'date'", column.ToString());
+
+            column.SetSortType(SortType.Float);
+            StringAssert.Contains("sorttype:'floate'", column.ToString());
+
+            column.SetSortType(SortType.Integer);
+            StringAssert.Contains("sorttype:'integer'", column.ToString());
+
+            column.SetSortType(SortType.Number);
+            StringAssert.Contains("sorttype:'number'", column.ToString());
+
+            column.SetSortType(SortType.Text);
+            StringAssert.Contains("sorttype:'text'", column.ToString());
+
+            JavascriptAssertColumn.IsValid(column);
+        }
+
         private static Column GetTestableColumn()
         {
             return new Column("testColumn");    

--- a/src/MvcJqGrid/Column.cs
+++ b/src/MvcJqGrid/Column.cs
@@ -37,6 +37,7 @@ namespace MvcJqGrid
         private EditOptions _editOptions;
         private EditRules _editRules;
         private EditFormOptions _editFormOptions;
+        private SortType? _sortType;
                 
         /// <summary>
         ///     Constructor
@@ -486,6 +487,12 @@ namespace MvcJqGrid
             return this;
         }
 
+        public Column SetSortType(SortType sortType)
+        {
+            _sortType = sortType;
+            return this;
+        }
+
         /// <summary>
         ///     Creates javascript string from column to be included in grid javascript
         /// </summary>
@@ -645,9 +652,12 @@ namespace MvcJqGrid
             if(_editFormOptions != null)
                 script.AppendFormat("formoptions:{0},", _editFormOptions.ToString()).AppendLine();
 
-            // Index
-            script.AppendFormat("index:'{0}'", _index).AppendLine();
+           if (_sortType.HasValue)
+                script.AppendFormat("sorttype:'{0}',", _sortType.ToString().ToLower()).AppendLine();
 
+           // Index
+           script.AppendFormat("index:'{0}'", _index).AppendLine();
+          
             // End column
             script.Append("}");
 

--- a/src/MvcJqGrid/Enums/SortType.cs
+++ b/src/MvcJqGrid/Enums/SortType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MvcJqGrid.Enums
+{
+    public enum SortType
+    {
+        Integer,
+        Float,
+        Currency,
+        Number,
+        Date,
+        Text
+    }
+}

--- a/src/MvcJqGrid/MvcJqGrid.csproj
+++ b/src/MvcJqGrid/MvcJqGrid.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Enums\SearchOptions.cs" />
     <Compile Include="Enums\Searchtype.cs" />
     <Compile Include="Enums\SortOrder.cs" />
+    <Compile Include="Enums\SortType.cs" />
     <Compile Include="Enums\ToolbarPosition.cs" />
     <Compile Include="Enums\TreeGridModel.cs" />
     <Compile Include="Extensions\ObjectExtensions.cs" />


### PR DESCRIPTION
When the column is type of decimal, date, currency etc, it was not
sorting correctly because the default sort type is text. Added a method
to set the sort type on column.

Here are the possible sorttype from jqgrid
(http://www.trirand.net/documentation/php/_2v70w5p2k.htm)

Used when datatype is local. Defines the type of the column for
appropriate sorting.Possible values:
int/integer - for sorting integer
float/number/currency - for sorting decimal numbers
date - for sorting date
text - for text sorting. The script automaticall fill this property.
